### PR TITLE
Fix unique_username to avoid collisions

### DIFF
--- a/contrib/utils.py
+++ b/contrib/utils.py
@@ -1,2 +1,13 @@
+from django.contrib.auth import get_user_model
+
+
 def unique_username(user):
-    return f'{user.first_name}_{user.last_name}'
+    """Generate a unique username based on first and last name."""
+    base_username = f"{user.first_name}_{user.last_name}".lower().replace(" ", "_")
+    username = base_username
+    UserModel = get_user_model()
+    counter = 1
+    while UserModel.objects.filter(username=username).exists():
+        counter += 1
+        username = f"{base_username}_{counter}"
+    return username


### PR DESCRIPTION
## Summary
- fix unique_username utility to generate distinct usernames

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684318c6e20c832286a07cce46b314ed