### PR TITLE
Add unique_username utility test

### DIFF
--- a/contrib/tests.py
+++ b/contrib/tests.py
@@ -1,3 +1,13 @@
 from django.test import TestCase
+from django.contrib.auth.models import User
 
-# Create your tests here.
+from .utils import unique_username
+
+
+class UniqueUsernameTests(TestCase):
+    """Tests for the ``unique_username`` utility."""
+
+    def test_unique_username_simple(self):
+        user = User(first_name="First", last_name="Last")
+        self.assertEqual(unique_username(user), "first_last")
+


### PR DESCRIPTION
## Summary
- add a test for `unique_username`

## Testing
- `flake8` *(fails: command not found)*
- `python manage.py test contrib.tests.UniqueUsernameTests.test_unique_username_simple` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68431b1f20448322a25593a26109ce78